### PR TITLE
Fixed unexpected EOF on compile process under gcc >=6 version

### DIFF
--- a/goid_386.s
+++ b/goid_386.s
@@ -11,3 +11,4 @@ TEXT ·getg(SB), NOSPLIT, $0-4
     MOVL    g(CX), AX
     MOVL    AX, ret+0(FP)
     RET
+

--- a/goid_amd64.s
+++ b/goid_amd64.s
@@ -10,3 +10,4 @@ TEXT ·getg(SB), NOSPLIT, $0-8
     MOVQ    g(CX), AX
     MOVQ    AX, ret+0(FP)
     RET
+

--- a/goid_arm.s
+++ b/goid_arm.s
@@ -9,3 +9,4 @@ TEXT ·getg(SB), NOSPLIT, $0-4
     MOVW    g, R8
     MOVW    R8, ret+0(FP)
     RET
+

--- a/goid_arm64.s
+++ b/goid_arm64.s
@@ -9,3 +9,4 @@ TEXT ·getg(SB), NOSPLIT, $0-8
     MOVD    g, R8
     MOVD    R8, ret+0(FP)
     RET
+


### PR DESCRIPTION
Hello,

I found a problem that occurs when compiling a module on the GCC >=6 version:
`github.com/modern-go/gls/goid_386.s:13: unexpected EOF`

<details><summary>My environment:</summary>
<p>

`$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/i686-linux-gnu/6/lto-wrapper
Target: i686-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 6.3.0-18+deb9u1' --with-bugurl=file:///usr/share/doc/gcc-6/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-6 --program-prefix=i686-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-6-i386/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-6-i386 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-6-i386 --with-arch-directory=i386 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --with-target-system-zlib --enable-objc-gc=auto --enable-targets=all --enable-multiarch --with-arch-32=i686 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=i686-linux-gnu --host=i686-linux-gnu --target=i686-linux-gnu
Thread model: posix
gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) `

</p>

<p>

`$ go version
go version go1.12.4 linux/386`

</p>
</details>

Please, accept the PR so that I can use the original repository.

Thank you for "gls" code.