### PR TITLE
Add support for riscv64

### DIFF
--- a/goid_riscv64.s
+++ b/goid_riscv64.s
@@ -1,0 +1,11 @@
+// Copyright 2016 Huan Du. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+TEXT ·getg(SB), NOSPLIT, $0-8
+    MOV    g, A0
+    MOV    A0, ret+0(FP)
+    RET


### PR DESCRIPTION
This implementation passed the `go test` check on riscv64.